### PR TITLE
Set visibility for class constants (PHP +7.1)

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -14,17 +14,17 @@ namespace Freelancehunt\Validators;
  */
 class CreditCard
 {
-    const TYPE_AMEX               = 'amex';
-    const TYPE_DANKORT            = 'dankort';
-    const TYPE_DINERS_CLUB        = 'diners_club';
-    const TYPE_DISCOVER           = 'discover';
-    const TYPE_FORBRUGSFORENINGEN = 'forbrugsforeningen';
-    const TYPE_JCB                = 'jcb';
-    const TYPE_MAESTRO            = 'maestro';
-    const TYPE_MASTERCARD         = 'mastercard';
-    const TYPE_UNIONPAY           = 'unionpay';
-    const TYPE_VISA               = 'visa';
-    const TYPE_VISA_ELECTRON      = 'visa_electron';
+    public const TYPE_AMEX               = 'amex';
+    public const TYPE_DANKORT            = 'dankort';
+    public const TYPE_DINERS_CLUB        = 'diners_club';
+    public const TYPE_DISCOVER           = 'discover';
+    public const TYPE_FORBRUGSFORENINGEN = 'forbrugsforeningen';
+    public const TYPE_JCB                = 'jcb';
+    public const TYPE_MAESTRO            = 'maestro';
+    public const TYPE_MASTERCARD         = 'mastercard';
+    public const TYPE_UNIONPAY           = 'unionpay';
+    public const TYPE_VISA               = 'visa';
+    public const TYPE_VISA_ELECTRON      = 'visa_electron';
 
     protected static $cards = [
         // Debit cards must come first, since they have more specific patterns than their credit-card equivalents.


### PR DESCRIPTION
Hi guys, would you like to update the visibility of the class constants to match the changes from php 7.1?