### PR TITLE
Added ELO, card used in Brazil.

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -25,6 +25,7 @@ class CreditCard
     const TYPE_UNIONPAY           = 'unionpay';
     const TYPE_VISA               = 'visa';
     const TYPE_VISA_ELECTRON      = 'visa_electron';
+    const TYPE_ELO                = 'elo';
 
     protected static $cards = [
         // Debit cards must come first, since they have more specific patterns than their credit-card equivalents.
@@ -104,6 +105,13 @@ class CreditCard
         self::TYPE_JCB                => [
             'type'      => self::TYPE_JCB,
             'pattern'   => '/^35/',
+            'length'    => [16],
+            'cvcLength' => [3],
+            'luhn'      => true,
+        ],
+        self::TYPE_ELO                => [
+            'type'      => self::TYPE_ELO,
+            'pattern'   => '/^4011|438935|45(1416|76)|50(4175|6699|67|90[4-7])|63(6297|6368)/',
             'length'    => [16],
             'cvcLength' => [3],
             'luhn'      => true,


### PR DESCRIPTION
ELO credit card added. - It is a very popular Credit Card used in Brazil.

Hello. I use your library to validate Credit Cards on my E-commerce hosted in Brazil. Here in Brazil we have a very popular Credit Card named ELO. As your library didn't validate this kind of card, I've added to your source code. To keep everything always updated, I am doing these pull request to merge my updated code to the master. I think it would be a very good update to both of us. Thank you.
Research source: 
- https://gist.github.com/erikhenrique/5931368
- https://gist.github.com/keitoliveira/cd4ee720bf1923a28be3